### PR TITLE
feat: add 'description' field for txns

### DIFF
--- a/lib/sos-demo.ts
+++ b/lib/sos-demo.ts
@@ -1,9 +1,6 @@
 import { StackorSpend } from "../sos"
 import { SQLiteDb } from "./get-db"
 
-// TODOS:
-// - ApiTxn.memo
-
 export const demoSoS = async () => {
   console.log("START")
   const db = SQLiteDb()

--- a/sos/src/app/fetch-txns.ts
+++ b/sos/src/app/fetch-txns.ts
@@ -28,6 +28,7 @@ const mapTxns = (txn): ApiTxn => {
     source: txn.source_name,
     sourceId: txn.source_tx_id,
     txStatus: txn.tx_status,
+    txDescription: txn.tx_description,
     sats: {
       amountWithFee: satsAmountWithFee,
       amount: satsAmount,

--- a/sos/src/app/index.types.d.ts
+++ b/sos/src/app/index.types.d.ts
@@ -29,6 +29,7 @@ type ApiTxn = {
   source: string
   sourceId: string
   txStatus: TxStatus
+  txDescription: string
   sats: {
     amountWithFee: number
     amount: number

--- a/sos/src/app/sync-txns.ts
+++ b/sos/src/app/sync-txns.ts
@@ -59,6 +59,7 @@ export const syncLatestTxns = async ({
         settlementPrice: { base },
         createdAt: timestamp,
         status,
+        memo,
         initiationVia: { paymentHash, address },
         settlementVia: { transactionHash: txId },
       } = tx.node
@@ -79,6 +80,7 @@ export const syncLatestTxns = async ({
         satsFee: -settlementFee,
         price: base / 10 ** 6,
         status,
+        description: memo || "",
         paymentHash,
         txId,
       })

--- a/sos/src/services/sqlite/index.types.d.ts
+++ b/sos/src/services/sqlite/index.types.d.ts
@@ -5,6 +5,7 @@ type INPUT_TXN = {
   satsFee: number
   price: number
   status: string
+  description: string
   paymentHash: string | undefined
   txId: string | undefined
 }
@@ -20,6 +21,7 @@ type Txn = {
       base: number
     }
     status: string
+    memo: string
     initiationVia: {
       paymentHash?: string
       address?: string

--- a/sos/src/services/sqlite/requests/create-txns-table.sql
+++ b/sos/src/services/sqlite/requests/create-txns-table.sql
@@ -20,6 +20,7 @@ CREATE TABLE IF NOT EXISTS transactions (
     source_name TEXT NOT NULL,
     source_tx_id TEXT NOT NULL UNIQUE,
     tx_status TEXT NOT NULL,
+    tx_description TEXT NOT NULL,
     ln_payment_hash TEXT,
     onchain_tx_id TEXT
 )

--- a/sos/src/services/sqlite/requests/insert-txn-alt.sql
+++ b/sos/src/services/sqlite/requests/insert-txn-alt.sql
@@ -9,8 +9,10 @@ INSERT INTO transactions (
     source_tx_id,
     ln_payment_hash,
     onchain_tx_id,
-    tx_status
+    tx_status,
+    tx_description
 ) VALUES (
+    ?,
     ?,
     ?,
     ?,

--- a/sos/src/services/sqlite/requests/insert-txn.sql
+++ b/sos/src/services/sqlite/requests/insert-txn.sql
@@ -9,7 +9,8 @@ INSERT INTO transactions (
     source_tx_id,
     ln_payment_hash,
     onchain_tx_id,
-    tx_status
+    tx_status,
+    tx_description
 ) VALUES (
     :sats_amount_with_fee,
     :sats_fee,
@@ -21,5 +22,6 @@ INSERT INTO transactions (
     :source_tx_id,
     :ln_payment_hash,
     :onchain_tx_id,
-    :tx_status
+    :tx_status,
+    :tx_description
 )

--- a/sos/src/services/sqlite/transactions-alt.ts
+++ b/sos/src/services/sqlite/transactions-alt.ts
@@ -49,6 +49,7 @@ CREATE TABLE IF NOT EXISTS transactions (
   source_name TEXT NOT NULL,
   source_tx_id TEXT NOT NULL UNIQUE,
   tx_status TEXT NOT NULL,
+  tx_description TEXT NOT NULL,
   ln_payment_hash TEXT,
   onchain_tx_id TEXT
 )
@@ -67,6 +68,7 @@ CREATE TABLE IF NOT EXISTS transactions (
   source_name TEXT NOT NULL,
   source_tx_id TEXT NOT NULL UNIQUE,
   tx_status TEXT NOT NULL,
+  tx_description TEXT NOT NULL,
   ln_payment_hash TEXT,
   onchain_tx_id TEXT
 )
@@ -85,9 +87,11 @@ INSERT INTO transactions (
   ln_payment_hash,
   onchain_tx_id,
   tx_status,
+  tx_description,
   fiat_amount_with_fee,
   fiat_fee
 ) VALUES (
+  ?,
   ?,
   ?,
   ?,
@@ -357,6 +361,7 @@ export const TransactionsRepositoryAlt = (db: SqliteDb) => {
 
           // TODO: figure how to check & finalize pending txns
           txn.status, // [":tx_status"]
+          txn.description, // [":tx_description"]
 
           (txn.sats * fiat_per_sat) / 10 ** 12, // [":fiat_amount_with_fee"]
           (txn.satsFee * fiat_per_sat) / 10 ** 12, // [":fiat_fee"]


### PR DESCRIPTION
## Description

Pulls in the `memo` field from upstream and adds it as a new `description` column in our local db and `ApiTxn` type