### PR TITLE
feat: get token from storage and toggle between environments

### DIFF
--- a/lib/async-storage.ts
+++ b/lib/async-storage.ts
@@ -9,6 +9,15 @@ export const storeAsyncStorageData = async (key, value) => {
   }
 }
 
+export const removeAsyncStorageData = async (key) => {
+  try {
+    await await AsyncStorage.getItem(key)
+  } catch (e) {
+    // saving error
+    console.log("Error saving to async storage", e)
+  }
+}
+
 export const getAsyncStorageData = async (key) => {
   try {
     const value = await AsyncStorage.getItem(key)

--- a/navigation/index.tsx
+++ b/navigation/index.tsx
@@ -1,13 +1,16 @@
 import * as React from "react"
 import { NavigationContainer } from "@react-navigation/native"
+import { GestureHandlerRootView } from "react-native-gesture-handler"
 
 import HomeStackNavigator from "./HomeStack"
 
 const RootNavigator = () => {
   return (
-    <NavigationContainer>
-      <HomeStackNavigator />
-    </NavigationContainer>
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <NavigationContainer>
+        <HomeStackNavigator />
+      </NavigationContainer>
+    </GestureHandlerRootView>
   )
 }
 

--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -406,13 +406,25 @@ const HomeScreen = () => {
         hitSlop={{ top: 20, bottom: 20 }}
         onPress={() => setCurrentBTCPrice(randomIntFromInterval(10000, 30000))}
       >
-        <TextMedium style={{ marginTop: 20 }}>
+        <TextMedium
+          adjustsFontSizeToFit={true}
+          numberOfLines={1}
+          color={colors.lightGrey}
+          size={15}
+          style={{ marginTop: 20 }}
+        >
           DEMO: Shuffle Current BTC Price | {toCurrency(currentBTCPrice)}
         </TextMedium>
+        <TextMedium
+          adjustsFontSizeToFit={true}
+          numberOfLines={1}
+          color={colors.lightGrey}
+          size={15}
+          style={{ marginTop: 10 }}
+        >
+          Actual BTC Price | {toCurrency(staticCurrentBTCPrice)}
+        </TextMedium>
       </Pressable>
-      <TextMedium style={{ marginTop: 10 }}>
-        Actual BTC Price | {toCurrency(staticCurrentBTCPrice)}
-      </TextMedium>
       {/* <View style={{ height: 130 }}>
         <ScrollView horizontal>
           {TAGGED.map((item, index) => (

--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -48,7 +48,7 @@ const GALOY_ENDPOINTS = {
 // - tappable toggle for price ✅
 // - transactions list clean up ✅
 // - toggle for bitcoin's current price ✅
-// - add a way to accept a unique token, store this in localstorage
+// - add a way to accept a unique token, store this in localstorage ✅
 // - add splash screen and logo ✅
 // - pass around correct stack/spend state ✅
 // - add reset button to blow up DB and start fresh ✅
@@ -70,7 +70,10 @@ const HomeScreen = () => {
   } | null>({ satsBalance: 0, fiatBalance: 0 })
   const [transactions, setTransactions] = useState<ApiTxn[]>([])
   const [assetDisplay, setAssetDisplay] = useState<"sats" | "fiat" | "btc">("sats")
-  const [galoyToken, setGaloyToken] = useState<string | null>("")
+  const [galoyToken, setGaloyToken] = useState<string | null>(
+    "",
+    // "nWL9JckgHA6uMjwuz6kkYrAowrpNXSas",
+  )
   const [staticCurrentBTCPrice, setStaticCurrentBTCPrice] = useState<number | null>(0)
   const [galoyTokenFromInput, setGaloyTokenFromInput] = useState<string | null>(null)
   const [initializing, setInitializing] = useState(true)
@@ -179,6 +182,7 @@ const HomeScreen = () => {
         opacity={0.8}
         disappearsOnIndex={-1}
         appearsOnIndex={0}
+        onPress={() => bottomSheetRef.current?.close()}
       />
     ),
     [],
@@ -450,7 +454,8 @@ const HomeScreen = () => {
       <BottomSheet
         ref={bottomSheetRef}
         index={-1}
-        enablePanDownToClose
+        enablePanDownToClose={true}
+        keyboardBehavior="interactive"
         snapPoints={snapPoints}
         backdropComponent={renderBackdrop}
       >

--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -70,10 +70,7 @@ const HomeScreen = () => {
   } | null>({ satsBalance: 0, fiatBalance: 0 })
   const [transactions, setTransactions] = useState<ApiTxn[]>([])
   const [assetDisplay, setAssetDisplay] = useState<"sats" | "fiat" | "btc">("sats")
-  const [galoyToken, setGaloyToken] = useState<string | null>(
-    "",
-    // "nWL9JckgHA6uMjwuz6kkYrAowrpNXSas",
-  )
+  const [galoyToken, setGaloyToken] = useState<string | null>("")
   const [staticCurrentBTCPrice, setStaticCurrentBTCPrice] = useState<number | null>(0)
   const [galoyTokenFromInput, setGaloyTokenFromInput] = useState<string | null>(null)
   const [initializing, setInitializing] = useState(true)

--- a/screens/SendScreen.tsx
+++ b/screens/SendScreen.tsx
@@ -106,11 +106,13 @@ export default function SendScreen() {
               title="Scan"
               icon={<MaterialCommunityIcons name="line-scan" size={24} color="white" />}
               small
+              clickHandler={() => {}}
             />
             <IconButton
               btnStyle={{ backgroundColor: textColor }}
               small
               icon={<Octicons name="paste" size={18} color="white" />}
+              clickHandler={() => {}}
             />
           </Actions>
         </>

--- a/screens/TransactionsScreen.tsx
+++ b/screens/TransactionsScreen.tsx
@@ -119,21 +119,12 @@ export default function TransactionsScreen() {
               {toFormattedNumber(Math.abs(selectedTransaction?.sats.fee))}
             </TextRegular>
             <DetailHeading>Invoice</DetailHeading>
-            {/* <TextRegular mBottom={25}>Saturday, November 12, 2022 12:53 AM</TextRegular> */}
+            <TextRegular mBottom={25}>{selectedTransaction?.txHash}</TextRegular>
           </View>
         </BottomSheet>
       </View>
     </SafeAreaView>
   )
-}
-
-type TransactionProps = {
-  id: number
-  date: string
-  name: string
-  type: "send" | "receive"
-  sats: number
-  transactionType: "lightning" | "bitcoin"
 }
 
 const TransactionItem = ({ item }: { item: ApiTxn }) => (
@@ -144,7 +135,8 @@ const TransactionItem = ({ item }: { item: ApiTxn }) => (
       justifyContent: "space-between",
       borderRadius: 4,
       marginBottom: 30,
-      padding: 20,
+      padding: 12,
+      paddingVertical: 20,
       shadowOffset: {
         width: 4,
         height: 3,
@@ -154,14 +146,21 @@ const TransactionItem = ({ item }: { item: ApiTxn }) => (
       backgroundColor: "white",
     }}
   >
-    <View>
+    <View style={{ flex: 0.5, width: 20 }}>
       {item.sats.amountWithFee < 0 ? (
-        <Feather name="arrow-up-right" size={24} color="grey" />
+        <Feather name="arrow-up-right" size={20} color="grey" />
       ) : (
-        <Feather name="arrow-down-left" size={24} color="grey" />
+        <Feather name="arrow-down-left" size={20} color="grey" />
       )}
     </View>
-    <View style={{ flexDirection: "row", alignItems: "center" }}>
+    <View
+      style={{
+        flexDirection: "row",
+        justifyContent: "center",
+        alignItems: "center",
+        flex: 2,
+      }}
+    >
       {item.txType === "BITCOIN" ? (
         <FontAwesome5
           style={{ marginRight: 8 }}
@@ -178,7 +177,7 @@ const TransactionItem = ({ item }: { item: ApiTxn }) => (
         />
       )}
       <View>
-        <TextRegular size={14} color="#939393">
+        <TextRegular size={11} color="#939393" numberOfLines={1}>
           {new Date(item.timestamp).toLocaleString("en-GB", {
             day: "numeric",
             month: "short",
@@ -190,8 +189,15 @@ const TransactionItem = ({ item }: { item: ApiTxn }) => (
         <TextRegular size={16}>{item.source}</TextRegular>
       </View>
     </View>
-    <View>
-      <TextSemibold>{Math.abs(item.sats.amountWithFee)} sats 💸</TextSemibold>
+    <View style={{ flex: 2 }}>
+      <TextSemibold
+        style={{ textAlign: "right" }}
+        adjustsFontSizeToFit={true}
+        numberOfLines={1}
+        size={14}
+      >
+        {toFormattedNumber(Math.abs(item.sats.amountWithFee))} sats 💸
+      </TextSemibold>
     </View>
   </View>
 )

--- a/screens/TransactionsScreen.tsx
+++ b/screens/TransactionsScreen.tsx
@@ -104,7 +104,7 @@ export default function TransactionsScreen() {
 
             <DetailHeading>Type</DetailHeading>
             <TextRegular mBottom={25}>
-              {selectedTransaction?.transactionType === "lightning"
+              {selectedTransaction?.txType === "LIGHTNING"
                 ? "Lightning Payment"
                 : "On-chain Payment"}
             </TextRegular>
@@ -162,7 +162,7 @@ const TransactionItem = ({ item }: { item: ApiTxn }) => (
       )}
     </View>
     <View style={{ flexDirection: "row", alignItems: "center" }}>
-      {/* {item.transactionType === "bitcoin" ? (
+      {item.txType === "BITCOIN" ? (
         <FontAwesome5
           style={{ marginRight: 8 }}
           name="bitcoin"
@@ -176,13 +176,7 @@ const TransactionItem = ({ item }: { item: ApiTxn }) => (
           size={24}
           color="#E7B416"
         />
-      )} */}
-      <MaterialCommunityIcons
-        style={{ marginRight: 8 }}
-        name="lightning-bolt-circle"
-        size={24}
-        color="#E7B416"
-      />
+      )}
       <View>
         <TextRegular size={14} color="#939393">
           {new Date(item.timestamp).toLocaleString("en-GB", {

--- a/screens/TransactionsScreen.tsx
+++ b/screens/TransactionsScreen.tsx
@@ -178,10 +178,10 @@ const TransactionItem = ({ item }: { item: ApiTxn }) => (
       )}
       <View>
         <TextRegular size={11} color="#939393" numberOfLines={1}>
-          {new Date(item.timestamp).toLocaleString("en-GB", {
+          {new Date(item.timestamp).toLocaleString("en-US", {
             day: "numeric",
             month: "short",
-            year: "numeric",
+            year: "2-digit",
             hour: "numeric",
             minute: "2-digit",
           })}
@@ -196,7 +196,7 @@ const TransactionItem = ({ item }: { item: ApiTxn }) => (
         numberOfLines={1}
         size={14}
       >
-        {toFormattedNumber(Math.abs(item.sats.amountWithFee))} sats 💸
+        {toFormattedNumber(item.sats.amountWithFee)} sats
       </TextSemibold>
     </View>
   </View>

--- a/styles/buttons/icon-button.tsx
+++ b/styles/buttons/icon-button.tsx
@@ -8,8 +8,6 @@ const Button = styled.View`
   background: ${(props) =>
     props.disabled
       ? colors.disabled
-      : props.white
-      ? props.background
       : props.background
       ? "white"
       : props.primary
@@ -38,8 +36,17 @@ const IconButton = ({
   secondary,
   small,
   style,
-  white,
   btnStyle,
+}: {
+  clickHandler: () => void
+  disabled?: boolean
+  icon: React.ReactNode
+  loading?: boolean
+  primary?: boolean
+  secondary?: boolean
+  small?: boolean
+  style?: any
+  btnStyle?: any
 }) => (
   <TouchableOpacity
     style={{ marginBottom: 10, ...style }}
@@ -53,7 +60,6 @@ const IconButton = ({
       disabled={disabled || loading}
       small={small}
       secondary={secondary}
-      white={white}
       primary={primary}
       style={{ ...btnStyle }}
     >

--- a/styles/buttons/main-button.tsx
+++ b/styles/buttons/main-button.tsx
@@ -48,6 +48,18 @@ const MainButton = ({
   title,
   white,
   btnStyle,
+}: {
+  clickHandler: () => void
+  disabled?: boolean
+  icon?: React.ReactNode
+  loading?: boolean
+  primary?: boolean
+  secondary?: boolean
+  small?: boolean
+  style?: any
+  title: string
+  white?: boolean
+  btnStyle?: any
 }) => (
   <TouchableOpacity
     style={{ marginBottom: 10, ...style }}


### PR DESCRIPTION
Introduces: 
- a way to set your token once and forget it. long press on the empty tagged transactions area.
- a way to choose between staging and production. this should probably be persisted in async storage too....
- improve transaction list style